### PR TITLE
Update defaults to eliminate error

### DIFF
--- a/MMM-OpenWeatherMapForecast.js
+++ b/MMM-OpenWeatherMapForecast.js
@@ -77,7 +77,6 @@ Module.register("MMM-OpenWeatherMapForecast", {
         showFeelsLike: true,
         language: config.language,
         iconset: "1c",
-        mainIconset: defaults.iconset,
         useAnimatedIcons: true,
         animateMainIconOnly: true,
         colored: true,


### PR DESCRIPTION
The current defaults definition can throw an error in certain circumstances because `mainIconset` refers to `defaults.iconset` _within_ the initial definition of `defaults`.  As far as I can tell, the reference to `defaults.iconset` is never actually needed anyway, as the later code just checks whether there is a `mainIconset` defined in the config file, and if not, uses `iconset`.  So I've removed `mainIconset` from the defaults defintion, which eliminates the error.

The error comes up for me when I run MMM-remote-control, which attempts to validate every other module.  