### PR TITLE
Update the summary to use the summary data from the daily API response

### DIFF
--- a/MMM-OpenWeatherMapForecast.js
+++ b/MMM-OpenWeatherMapForecast.js
@@ -279,9 +279,7 @@ Module.register("MMM-OpenWeatherMapForecast", {
         if (this.config.concise) {
             summary = this.weatherData.hourly ? this.weatherData.hourly[0].weather[0].description : this.weatherData.current.weather[0].description;
         } else {
-            summary = (this.weatherData.current.weather[0].description + ".") + " " +
-                (this.weatherData.hourly ? this.weatherData.hourly[0].weather[0].description + " " : "") +
-                (this.weatherData.daily ? this.weatherData.daily[0].weather[0].description : "");
+            summary = this.weatherData.daily ? this.weatherData.daily[0].summary : "";
         }
 
         var hourlies = [];


### PR DESCRIPTION
Adding together all of the descriptions wasn't really that useful, as a lot of the times it was repeated information. The daily summary from the API response is a lot better and what I was expecting to see when displaying a non-concise summary.